### PR TITLE
Add flow field tower defense demo

### DIFF
--- a/towerDefenseDemo/README.md
+++ b/towerDefenseDemo/README.md
@@ -1,0 +1,13 @@
+# TowerDefenseDemo
+
+A minimal tower defense example built with Processing. It demonstrates using a GPU
+based flow field shader for enemy pathfinding. Enemies spawn in waves and move
+around obstacles towards a base. A simple UI lets you pick a turret type and
+place towers by clicking.
+
+* Select turrets with number keys **1-3** and click to place them.
+* Each tower blocks the path field and attacks nearby enemies.
+* Waves of enemies spawn automatically and pathfind to the base location.
+
+The sketch is not a full game but shows how a flow field can control many
+entities at once while interacting with towers and obstacles.

--- a/towerDefenseDemo/collisionMap.pde
+++ b/towerDefenseDemo/collisionMap.pde
@@ -1,0 +1,39 @@
+ArrayList<WallRect> walls = new ArrayList<WallRect>();
+ArrayList<Tower> towers = new ArrayList<Tower>();
+ArrayList<Enemy> enemies = new ArrayList<Enemy>();
+
+void genObstacles() {
+  walls.add(new WallRect(width/2 - 50, height/2 - 100, 100, 200));
+  walls.add(new WallRect(width/4, height/3, 80, 80));
+  walls.add(new WallRect(3*width/4, 2*height/3, 80, 80));
+}
+
+void updateCollisionMap() {
+  pgCollisionMap.beginDraw();
+  pgCollisionMap.background(1);
+  pgCollisionMap.fill(255, 0, 0);
+  pgCollisionMap.noStroke();
+  for (WallRect w : walls) w.draw(pgCollisionMap);
+  for (Tower t : towers) t.drawToMap(pgCollisionMap);
+  pgCollisionMap.endDraw();
+}
+
+class WallRect {
+  float x, y, w, h;
+  WallRect(float x, float y, float w, float h) {
+    this.x = x; this.y = y; this.w = w; this.h = h;
+  }
+  void draw(PGraphics pg) {
+    pg.rect(x, y, w, h);
+  }
+  boolean contains(float px, float py) {
+    return px >= x && px <= x+w && py >= y && py <= y+h;
+  }
+}
+
+boolean canPlaceTower(float x, float y) {
+  if (dist(x, y, baseLocation.x, baseLocation.y) < 30) return false;
+  for (WallRect w : walls) if (w.contains(x, y)) return false;
+  for (Tower t : towers) if (t.loc.dist(new PVector(x, y)) < 20) return false;
+  return true;
+}

--- a/towerDefenseDemo/drawShapes.glsl
+++ b/towerDefenseDemo/drawShapes.glsl
@@ -1,0 +1,53 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+uniform vec2 u_mouse;
+uniform vec4 lines[50]; //unifrom
+uniform float thick[50]; //uniform
+uniform vec2 enemies[924]; 
+
+vec4 red = vec4(1.0,0.0,0.0,1.0);
+vec4 black = vec4(0.004,0.004,0.004,1.0);
+vec4 result;
+
+vec2 project(vec2 A, vec2 B, vec2 C){
+    vec2 L = B-A;
+    float K = dot(C-A,L);
+    K/= dot(L,L);
+    return A+L*K;
+}
+vec2 constrain (vec2 amt, vec2 low, vec2 high){
+    return min(max(amt,min(low,high)),max(low,high));
+}
+
+bool closerThan(float len, vec2 A, vec2 B){
+  vec2 del = A-B;
+  del*=del;
+  len*=len;
+  return del.x+del.y < len;
+}
+
+bool line (vec4 lin, float thickness){
+    vec2 start = vec2(lin.xy);
+    vec2 end = vec2(lin.zw);
+    vec2 D = constrain(project(start,end,gl_FragCoord.xy),start,end);
+    if ( closerThan ( thickness,gl_FragCoord.xy,D) ) { 
+        return true; 
+    }
+    return false;
+}
+
+void main() {
+	result = black;
+    for (int i = 0; i<50; i++){
+    	if (line(lines[i],thick[i])){
+        	result =red;
+    	}
+    }
+
+ 
+ 	for (int i = 0; i<924; i++){
+    	if (closerThan(2.,enemies[i].xy ,  gl_FragCoord.xy)) result = red;
+    }
+	gl_FragColor = result;
+}

--- a/towerDefenseDemo/enemy.pde
+++ b/towerDefenseDemo/enemy.pde
@@ -1,0 +1,65 @@
+class Enemy {
+  PVector loc;
+  PVector vel = new PVector();
+  float speed = 2.0;
+  int hp = 3;
+  final int radius = 4;
+  final int s = radius + 2;
+  final int w = width, h = height, totPxls = w*h - w, ws = w*s;
+
+  Enemy(PVector start) {
+    loc = start.copy();
+  }
+
+  void update() {
+    move();
+    fill(0, 0, 255);
+    noStroke();
+    ellipse(loc.x, loc.y, radius * 2, radius * 2);
+  }
+
+  boolean reachedGoal() {
+    return loc.dist(baseLocation) < 10;
+  }
+
+  void damage(int amt) {
+    hp -= amt;
+  }
+
+  boolean dead() {
+    return hp <= 0;
+  }
+
+  void move() {
+    vel.lerp(getDirection(loc), 0.1);
+    loc.add(vel.copy().mult(speed));
+    loc.x = constrain(loc.x, 1, width - 2);
+    loc.y = constrain(loc.y, 1, height - 2);
+  }
+
+  PVector getDirection(PVector ploc) {
+    if (ploc.y < 0) return new PVector(0, 1);
+    PVector tv = ploc.copy();
+    int tx = constrain(ceil(tv.x), 0, w - 2);
+    int ty = constrain(round(tv.y) - 1, 0, h - 1);
+    return getDirection(tx + ty * w);
+  }
+
+  PVector getDirection(int ijq) {
+    PVector dir = new PVector();
+    int ind = min(ijq + s, totPxls);
+    dir.x += brightnessDecode(pgPathMap.pixels[ind]);
+    ind = max(ijq - s, 0);
+    dir.x -= brightnessDecode(pgPathMap.pixels[ind]);
+    ind = min(ijq + ws, totPxls);
+    dir.y += brightnessDecode(pgPathMap.pixels[ind]);
+    ind = max(ijq - ws, 0);
+    dir.y -= brightnessDecode(pgPathMap.pixels[ind]);
+    dir.normalize();
+    return dir;
+  }
+}
+
+int brightnessDecode(color c) {
+  return int(red(c) + blue(c) + green(c));
+}

--- a/towerDefenseDemo/pathFlow.glsl
+++ b/towerDefenseDemo/pathFlow.glsl
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Logan McCandless
+ * MIT License: https://opensource.org/licenses/MIT
+ */
+
+#version 150 
+
+precision mediump float;
+precision mediump int;
+
+out vec4 glFragColor;
+
+#define PROCESSING_TEXTURE_SHADER
+
+uniform sampler2D texture;
+uniform sampler2D tex_obstacles;
+uniform vec2 texOffset;
+uniform mat4 texMatrix;
+
+varying vec4 vertColor;
+varying vec4 vertTexCoord;
+
+uniform vec2 mouse;
+uniform vec2 resolution;
+uniform sampler2D ppixels;
+
+vec4 white  = vec4(1.0, 1.0, 1.0, 1.0);
+
+void main( void ) {
+  vec2 position = ( gl_FragCoord.xy / resolution.xy );
+  if (texture2D(tex_obstacles, position).r <1.0) {
+    if (length(position-mouse) < 0.002) {
+      gl_FragColor = white;
+    } 
+    else {
+      // cardinals 1px away
+      vec2 tc5 = vertTexCoord.st + vec2( 0.0, texOffset.t);
+      vec2 tc6 = vertTexCoord.st + vec2( 0.0, -texOffset.t);
+      vec2 tc7 = vertTexCoord.st + vec2(+texOffset.s, 0.0);
+      vec2 tc8 = vertTexCoord.st + vec2(-texOffset.s, 0.0);
+      // Get step distances/blue , reduce diagnals by sqrt(2)
+      float b5 = texture2D(tex_obstacles, tc5).r;
+      float b6 = texture2D(tex_obstacles, tc6).r;
+      float b7 = texture2D(tex_obstacles, tc7).r;
+      float b8 = texture2D(tex_obstacles, tc8).r;
+      if (b5 < 1.0) b5= texture2D(ppixels, tc5).r + texture2D(ppixels, tc5).g + texture2D(ppixels, tc5).b;  else b5 = -1.0; 
+      if (b6 < 1.0) b6= texture2D(ppixels, tc6).r + texture2D(ppixels, tc6).g + texture2D(ppixels, tc6).b;  else b6 = -1.0; 
+      if (b7 < 1.0) b7= texture2D(ppixels, tc7).r + texture2D(ppixels, tc7).g + texture2D(ppixels, tc7).b;  else b7 = -1.0; 
+      if (b8 < 1.0) b8= texture2D(ppixels, tc8).r + texture2D(ppixels, tc8).g + texture2D(ppixels, tc8).b;  else b8 = -1.0; 
+      // Find the highest neighbor value
+      b5 = max(b5, b6);
+      b7 = max(b7, b8);
+      b5 = max(b5, b7); 
+      float b1 = b5 - 0.006;
+      // Brightness encode
+      float bk =  (b1*85);
+      bk = bk - floor(bk);
+      float r1 = 0, r2 = 0;
+      if (bk >0.33333) r1 = 0.00390625;
+      if (bk >0.66666) r2 = 0.00390625;
+      float b5r = float(b1)/3.0;
+      gl_FragColor = vec4(b5r, b5r+r2, b5r+r1, 1.);
+    }
+  }
+}

--- a/towerDefenseDemo/tower.pde
+++ b/towerDefenseDemo/tower.pde
@@ -1,0 +1,50 @@
+class Tower {
+  PVector loc;
+  int type;
+  float range;
+  int maxCooldown;
+  int cooldown = 0;
+
+  Tower(float x, float y, int t) {
+    loc = new PVector(x, y);
+    type = t;
+    if (t == 0) { // basic
+      range = 70;
+      maxCooldown = 30;
+    } else if (t == 1) { // slow but strong
+      range = 90;
+      maxCooldown = 60;
+    } else { // rapid fire
+      range = 60;
+      maxCooldown = 15;
+    }
+  }
+
+  void update() {
+    if (cooldown > 0) cooldown--;
+    Enemy target = null;
+    for (Enemy e : enemies) {
+      if (!e.dead() && e.loc.dist(loc) < range) {
+        target = e;
+        break;
+      }
+    }
+    if (target != null && cooldown == 0) {
+      target.damage(1);
+      cooldown = maxCooldown;
+    }
+  }
+
+  void drawTower() {
+    rectMode(CENTER);
+    fill(100, 100, 0);
+    if (type == 1) fill(0, 100, 100);
+    if (type == 2) fill(100, 0, 100);
+    rect(loc.x, loc.y, 16, 16);
+  }
+
+  void drawToMap(PGraphics pg) {
+    pg.rectMode(CENTER);
+    pg.rect(loc.x, loc.y, 16, 16);
+  }
+}

--- a/towerDefenseDemo/towerDefenseDemo.pde
+++ b/towerDefenseDemo/towerDefenseDemo.pde
@@ -1,0 +1,87 @@
+PShader pathFlow;
+PGraphics pgPathMap;
+PGraphics pgCollisionMap;
+PVector baseLocation;
+
+float gpuPasses = 8;
+int selectedTurret = 0;
+String[] turretNames = {"Basic", "Slow", "Rapid"};
+int nextWave = 0;
+int enemiesPerWave = 5;
+
+void setup() {
+  size(800, 600, P2D);
+  frameRate(60);
+  pgPathMap = createGraphics(width, height, P2D);
+  pgPathMap.noSmooth();
+  pgCollisionMap = createGraphics(width, height, P2D);
+  pgCollisionMap.noSmooth();
+  pathFlow = loadShader("pathFlow.glsl");
+  pathFlow.set("resolution", float(pgPathMap.width), float(pgPathMap.height));
+  pathFlow.set("tex_obstacles", pgCollisionMap);
+  baseLocation = new PVector(width - 40, height/2);
+  genObstacles();
+  spawnWave();
+}
+
+void draw() {
+  updateCollisionMap();
+  gpuPathTrace();
+
+  pgPathMap.loadPixels();
+  for (Tower t : towers) t.update();
+  for (int i = enemies.size()-1; i>=0; i--) {
+    Enemy e = enemies.get(i);
+    e.update();
+    if (e.dead()) enemies.remove(i);
+    else if (e.reachedGoal()) enemies.remove(i);
+  }
+
+  if (frameCount > nextWave) {
+    spawnWave();
+    nextWave = frameCount + 600;
+  }
+
+  fill(0,255,0);
+  noStroke();
+  ellipse(baseLocation.x, baseLocation.y, 20, 20);
+
+  drawUI();
+}
+
+void gpuPathTrace() {
+  pathFlow.set("mouse", map(baseLocation.x, 0, width, 0, 1), map(baseLocation.y, 0, height, 1, 0));
+  int i = int(gpuPasses);
+  while (i-- > 0) {
+    pgPathMap.beginDraw();
+    pgPathMap.image(pgCollisionMap, 0, 0);
+    pgPathMap.filter(pathFlow);
+    pgPathMap.endDraw();
+  }
+  image(pgPathMap, 0, 0, width, height);
+}
+
+void spawnWave() {
+  for (int i = 0; i < enemiesPerWave; i++) {
+    enemies.add(new Enemy(new PVector(40, 50 + i*20)));
+  }
+}
+
+void drawUI() {
+  fill(0);
+  rect(0, height-30, width, 30);
+  fill(255);
+  text("Turret: " + turretNames[selectedTurret] + " (1-3 to select) | Click to place", 10, height-10);
+}
+
+void mousePressed() {
+  if (mouseY < height-30 && canPlaceTower(mouseX, mouseY)) {
+    towers.add(new Tower(mouseX, mouseY, selectedTurret));
+  }
+}
+
+void keyPressed() {
+  if (key == '1') selectedTurret = 0;
+  if (key == '2') selectedTurret = 1;
+  if (key == '3') selectedTurret = 2;
+}


### PR DESCRIPTION
## Summary
- add a simple tower defense example using the flow-field shader
- include basic enemy, tower and obstacle classes
- wave spawner and UI for turret selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e3e2aa628832fa9f576456a0a5efb